### PR TITLE
Implement graceful shutdowns

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
 src/node_modules
+.github
+.gitignore
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ ENV NODE_ENV=production
 
 ADD src /app
 WORKDIR /app
-RUN npm install --production
+RUN npm install --omit=dev
 
 CMD ["node", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:alpine
+ENV NODE_ENV=production
 
 ADD src /app
 WORKDIR /app
-RUN npm install
+RUN npm install --production
 
-CMD ["npm", "start"]
+CMD ["node", "index.js"]

--- a/src/index.js
+++ b/src/index.js
@@ -100,4 +100,25 @@ async function main() {
 
 }
 
+// The signals we want to handle
+var signals = {
+  'SIGHUP': 1,
+  'SIGINT': 2,
+  'SIGTERM': 15
+};
+
+// Do any necessary shutdown logic for our application here
+const shutdown = (signal, value) => {
+  console.log(`LDS stopped by ${signal} with value ${value}`);
+  process.exit(128 + value);
+};
+
+// Create a listener for each of the signals that we want to handle
+Object.keys(signals).forEach((signal) => {
+  process.on(signal, () => {
+    console.log(`Process received a ${signal} signal`);
+    shutdown(signal, signals[signal]);
+  });
+});
+
 main();

--- a/src/index.js
+++ b/src/index.js
@@ -101,10 +101,10 @@ async function main() {
 }
 
 // The signals we want to handle
-var signals = {
-  'SIGHUP': 1,
-  'SIGINT': 2,
-  'SIGTERM': 15
+const signals = {
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGTERM: 15,
 };
 
 // Do any necessary shutdown logic for our application here
@@ -114,11 +114,11 @@ const shutdown = (signal, value) => {
 };
 
 // Create a listener for each of the signals that we want to handle
-Object.keys(signals).forEach((signal) => {
+for (const [signal, value] of Object.entries(signals)) {
   process.on(signal, () => {
-    console.log(`Process received a ${signal} signal`);
-    shutdown(signal, signals[signal]);
+    console.log(`Process received a ${signal} signal, shutting down...`);
+    shutdown(signal, value);
   });
-});
+}
 
 main();


### PR DESCRIPTION
Currently this container does not stop until it gets terminated by Docker after it fails to stop for 10 seconds.

On my system this timeout is 240 seconds, so I implemented a signal handler to gracefully shutdown the container and make it stop cleanly, so that I dont have to wait 2 minutes.

Ideally, it would finish the tasks in the timer before shutting down (if needed), but this a first step in the right direction.